### PR TITLE
Use proper optimization flags for gfortran

### DIFF
--- a/examples/speed_comparision.ipynb
+++ b/examples/speed_comparision.ipynb
@@ -127,7 +127,7 @@
    },
    "outputs": [],
    "source": [
-    "%%fortran\n",
+    "%%fortran --f90flags \"-march=native -ffast-math\"\n",
     "\n",
     "    subroutine abc_model_fortran(col_dim, a, b, c, inflow, outflow)\n",
     "\n",


### PR DESCRIPTION
The best performance is typically achieved using the following flags:

-O3 -march=native -ffast-math -funroll-loops

The -O3 and -funroll-loops are already supplied by f2py, but the other two
flags were missing. This commit adds them. This speeds the Fortran benchmark on
my machine.