### PR TITLE
update as_matrix to to_numpy in tests

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -233,7 +233,7 @@ class TestCemaneige(unittest.TestCase):
                                    df.max_temp, met_station_height=495, 
                                    altitudes=[550, 620, 700, 785, 920])
         self.assertTrue(np.allclose(qsim.flatten(), 
-                                    df.liquid_outflow.as_matrix()))
+                                    df.liquid_outflow.to_numpy()))
         
 class TestCemaneigeGR4J(unittest.TestCase):
     """Test the Cemaneige + GR4J couple model.
@@ -265,4 +265,4 @@ class TestCemaneigeGR4J(unittest.TestCase):
                                    altitudes=[550, 620, 700, 785, 920],
                                    s_init=0.6, r_init=0.7)
         self.assertTrue(np.allclose(qsim.flatten(), 
-                                    df.qsim.as_matrix()))
+                                    df.qsim.to_numpy()))


### PR DESCRIPTION
Removed in pandas 1.0 as stated in https://pandas.pydata.org/docs/whatsnew/v1.0.0.html

Nice playground! Just a small fix to keep the tests green with pandas 1.0.