### PR TITLE
Fix HBV-edu simulation with return_storages

### DIFF
--- a/rrmpg/models/hbvedu.py
+++ b/rrmpg/models/hbvedu.py
@@ -201,7 +201,7 @@ class HBVEdu(BaseModel):
                 # call the actual simulation function
                 (qsim[:, i], snow[:, i], soil[:, i], s1[:, i],
                  s2[:, i]) = run_hbvedu(temp, prec, month, PE_m, T_m, snow_init, soil_init, s1_init,
-                                        s2_init, params)
+                                        s2_init, params[i])
 
             else:
                 # call the actual simulation function


### PR DESCRIPTION
The `run_hbvedu` call in HBVEdu was missing the index into the `params` array, causing a numba type error down the line (max(float, array[float]) instead of max(float, float) in https://github.com/kratzert/RRMPG/blob/master/rrmpg/models/hbvedu_model.py#L94).